### PR TITLE
Add `db_engine` field to source db parser

### DIFF
--- a/backend/bms_app/source_db/parsers.py
+++ b/backend/bms_app/source_db/parsers.py
@@ -44,13 +44,14 @@ class MigvisorParser:
 
     COLUMNS_TO_PARSE = [
         'server', 'oracle_version', 'arch', 'cores', 'ram',
-        'allocated_memory', 'db_name', 'db_size'
+        'allocated_memory', 'db_name', 'db_size', 'db_engine'
     ]
     COLUMNS_MAP = {
         'architecture': 'arch',
         'allocated memory': 'allocated_memory',
         'database name': 'db_name',
         'database size (gb)': 'db_size',
+        'database type': 'db_engine',
         'version': 'oracle_version'
     }
     DATABASE_SERVERS_SHEET = 'Database Servers'
@@ -221,6 +222,9 @@ class MigvisorParser:
         # make sure 'oracle_version' is string
         df['oracle_version'] = df['oracle_version'].apply(
             lambda x: None if x is None else str(x)
+        )
+        df['db_engine'] = df['db_engine'].apply(
+            lambda engine: str.upper(engine)
         )
 
         return df.to_dict(orient='records')

--- a/backend/bms_app/source_db/services.py
+++ b/backend/bms_app/source_db/services.py
@@ -33,11 +33,14 @@ class InSourceDBSchema(ma.SQLAlchemyAutoSchema):
 
     @post_load
     def db_type(self, data, many, **kwargs):
-        if data['rac_nodes']:
+        if 'db_engine' in data and data['db_engine'] != 'ORACLE':
+            data['db_type'] = None
+        elif 'rac_nodes' in data and data['rac_nodes']:
             data['db_type'] = SourceDBType.RAC
         else:
             data['db_type'] = SourceDBType.SI
 
+        print(data)
         return data
 
 
@@ -68,7 +71,7 @@ class InASMConfig(Schema):
 in_db_schema = InSourceDBSchema(
     only=['server', 'oracle_version', 'arch', 'cores', 'ram',
           'allocated_memory', 'db_name', 'db_size', 'oracle_release',
-          'rac_nodes']
+          'rac_nodes', 'db_engine']
 )
 
 
@@ -79,7 +82,7 @@ def update_db_config(source_db, raw_db_data):
 
     upd_data = {
         'db_id': source_db.id,
-        'asm_config_values': asm_data['asm'],
+        'asm_config_values': asm_data['asm'] if 'asm' in asm_data else None,
         'misc_config_values': misc_data
 
     }


### PR DESCRIPTION
## Summary

`Database type` column of the MigVisor report is parsed into the `db_engine` field.
This allows to load different database types (Oracle, Postgres..) to the tool.